### PR TITLE
Allow more nodetypes and check for bind address 127.0.0.1

### DIFF
--- a/backup.jps
+++ b/backup.jps
@@ -11,6 +11,12 @@ baseUrl: https://raw.githubusercontent.com/shaundma/database-backup-addon/master
 targetNodes:
   nodeType:
     - llsmp
+    - litespeedphp
+    - nginxphp-dockerized
+    - nginx-dockerized
+    - Node.js
+    - almalinux-vps
+    - ubuntu-vps
     - lemp
     - apache
     - redis

--- a/backup.jps
+++ b/backup.jps
@@ -6,10 +6,13 @@ targetEditions: any
 logo: /images/backup-logo.png
 description: Backup Add-On for the database. It can be used to create scheduled backups according to any required timezone and restore corrupted databases, even if the content has been completely deleted.
 
-baseUrl: https://raw.githubusercontent.com/jelastic-jps/database-backup-addon/master
+baseUrl: https://raw.githubusercontent.com/shaundma/database-backup-addon/master
 
 targetNodes:
-  nodeType: 
+  nodeType:
+    - cp
+    - lemp
+    - apache
     - redis
     - redis7
     - redis6

--- a/backup.jps
+++ b/backup.jps
@@ -10,7 +10,7 @@ baseUrl: https://raw.githubusercontent.com/shaundma/database-backup-addon/master
 
 targetNodes:
   nodeType:
-    - cp
+    - llsmp
     - lemp
     - apache
     - redis

--- a/scripts/backup-logic.sh
+++ b/scripts/backup-logic.sh
@@ -151,6 +151,14 @@ function backup(){
     else
         SERVER_IP_ADDR=$(ip a | grep -A1 venet0 | grep inet | awk '{print $2}'| sed 's/\/[0-9]*//g' | tail -n 1)
         [ -n "${SERVER_IP_ADDR}" ] || SERVER_IP_ADDR="localhost"
+ 	# additional check for port 3306 on 127.0.0.1
+  	ns_output=$(netstat -tnlp | grep ':3306' | awk '{print $4}' | cut -d: -f1)
+   	for ip in $ns_output; do
+  		if [ "$ip" == "127.0.0.1" ]; then
+       			SERVER_IP_ADDR="localhost"
+  		fi
+	done
+ 	# end additional check
         if which mariadb 2>/dev/null; then
             CLIENT_APP="mariadb"
         else

--- a/scripts/mariadb-restore.sh
+++ b/scripts/mariadb-restore.sh
@@ -2,6 +2,14 @@
 
 SERVER_IP_ADDR=$(ip a | grep -A1 venet0 | grep inet | awk '{print $2}'| sed 's/\/[0-9]*//g' | tail -n 1)
 [ -n "${SERVER_IP_ADDR}" ] || SERVER_IP_ADDR="localhost"
+# additional check for port 3306 on 127.0.0.1
+ns_output=$(netstat -tnlp | grep ':3306' | awk '{print $4}' | cut -d: -f1)
+for ip in $ns_output; do
+    if [ "$ip" == "127.0.0.1" ]; then
+        SERVER_IP_ADDR="localhost"
+  	fi
+done
+# end additional check
 if which mariadb 2>/dev/null; then
     CLIENT_APP="mariadb"
 else


### PR DESCRIPTION
These changes allow the add-on to work with more nodetypes, not just database nodes. 
llsmp and LEMP nodes have mariadb, so they also needs to be backupped, preferably all the same way...
This is more user friendly and easier to setup than the manual backup.